### PR TITLE
Fix DockerImageName secondary constructor

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/DockerImageName.java
+++ b/core/src/main/java/org/testcontainers/utility/DockerImageName.java
@@ -61,7 +61,7 @@ public final class DockerImageName {
             registry = "";
             remoteName = name;
         } else {
-            registry = name.substring(0, slashIndex - 1);
+            registry = name.substring(0, slashIndex);
             remoteName = name.substring(slashIndex + 1);
         }
 


### PR DESCRIPTION
It was cutting down last char of registry name